### PR TITLE
Fix Rumble Capes API endpoint

### DIFF
--- a/src/main/java/net/litetex/capes/provider/RumbleCapeProvider.java
+++ b/src/main/java/net/litetex/capes/provider/RumbleCapeProvider.java
@@ -36,7 +36,7 @@ public class RumbleCapeProvider implements CapeProvider
 	@Override
 	public String getBaseUrl(final GameProfile profile)
 	{
-		return "http://rumblecapes.xyz/capes/" + profile.name() + ".png";
+		return "http://api.rumblecapes.xyz/capes/" + profile.name() + ".png";
 	}
 	
 	@Override


### PR DESCRIPTION
This fixes the API for Rumble Capes from http://https://rumblecapes.xyz to http://api.rumblecapes.xyz